### PR TITLE
Change handle_lock_state_change to discard events without a user id - letting handle_zwave_js_lock_event handle it instead

### DIFF
--- a/custom_components/keymaster/coordinator.py
+++ b/custom_components/keymaster/coordinator.py
@@ -526,6 +526,10 @@ class KeymasterCoordinator(DataUpdateCoordinator):
         if not event:
             return
 
+        # Ignore events without a user_id - they're from zwave - let handle_zwave_js_lock_event handle it
+        if event.context.as_dict()["user_id"] is None:
+            return
+
         changed_entity: str = event.data["entity_id"]
 
         # Don't do anything if the changed entity is not this lock


### PR DESCRIPTION
## Symptom
You have this issue if you notice that lock events from the lock are processed as their _opposite_ in keymaster - you get Door unlock notifications when you lock the door, for example.

## Breaking change
It should not be a breaking change unless the lock doesn't send any zwave notification messages when it is operated, which probably means it's not going to work very well with this system anyway (and is probably pretty broken in HA in general in that case).

## Proposed change
This fix discards state changes without a user_id in handle_lock_state_change. The reasoning is simple - handle_lock_state_change is fired WAY too early during the zwave lock notification process and sees very wrong values for the other elements of zwave lock state, at least with my schlage lock testing. (This is because zwave is actually a whole negotiation - with many different things changing and notifications flying back and forth from the lock to HA and back again, and the state change on the lock entity in HA is one of the very earliest in the sequence at least with my Schlage lock).

Anyway, the key problem for the notification code is that the state change fires WAY before the zwave _notification_ that the lock has changed state, which is a much more reliable method of getting audit information about the changing state of the lock, such as what happened and who caused it. Due to this out of sequence behaviour, handle_lock_state_change would fire well before handle_zwave_js_lock_event and the former would make very wrong assumptions based on the transient state the lock is in at the time that event is fired (usually, it would emit a notification event based on the _prior_ state of the lock - so a Lock event from the lock would fire a notification as an Unlock event, because none of the sensors containing the lock state information had been updated _except the lock entity itself_.

This change is simple: if the lock state change event _has_ a user ID it has come from HA and NOT zwave, and thus we can act on it (I can't seem to get zwave to send a _notification_ back if we programmatically change the lock state from HA, which is annoying), but if it _doesn't_ have a user ID, it is an event that is part of an external change in state. As such, it's firing WAY too early in this circumstance, and should just be ignored - wait for the real zwave notification event instead.

Edit: something else to note - events have a whole LOCAL/REMOTE thing, but zwave events are ALL local all the time, so you can't reliably use that to detect if the event came from the lock or from a user in HA. (That is _probably_ a bug in the zwave stuff - I would expect an event triggered from a zwave action outside HA to carry the remote flag, but ho hum).

## Type of change
- [ ] Dependency upgrade
- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (which adds functionality)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
- This PR fixes or closes issue: fixes #449 maybe others as well, there's a lot of notification bugs at present
- This PR is related to issue: #449 for sure, but generally that zwave notifications are just busted

Thing to note: This issue slightly caused because I configured the Alarm Level/User Code and Alarm Type/Access Control sensors for my locks. It is also worth noting that it seems that zwave locks are pretty weird in general in HA as far as I can tell. There might be better ways to handle this situation - but, at least for me, locally, this fix has completely fixed notifications that I care about from my locks.